### PR TITLE
Additional Accessors for Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ $grandchild->getAncestors(); // Returns [$root, $child]
 ```
 
 #### Related Methods
-- `getAncestorsWithoutRoot` retrieves ancestors of a node, excluding the root node.
 - `getAncestorsAndSelf` retrieves ancestors of a node with the current node included.
-- `getAncestorsAndSelfWithoutRoot` retrieves ancestors of a node, including current node, excluding the root node.
-
 
 ### Getting the root of a node
 ```php

--- a/src/Tree/Node/NodeInterface.php
+++ b/src/Tree/Node/NodeInterface.php
@@ -99,25 +99,11 @@ interface NodeInterface
     public function getAncestors();
 
     /**
-     * Retrieves all ancestors of node, excluding root.
-     *
-     * @return Node[]
-     */
-    public function getAncestorsWithoutRoot();
-
-    /**
      * Retrieves all ancestors of node as well as the node itself.
      *
      * @return Node[]
      */
     public function getAncestorsAndSelf();
-
-    /**
-     * Retrieves all ancestors, including current node, excluding root.
-     *
-     * @return Node[]
-     */
-    public function getAncestorsAndSelfWithoutRoot();
 
     /**
      * Retrieves all neighboring nodes, excluding the current node.

--- a/src/Tree/Node/NodeTrait.php
+++ b/src/Tree/Node/NodeTrait.php
@@ -153,25 +153,12 @@ trait NodeTrait
         return $parents;
     }
 
-    public function getAncestorsWithoutRoot()
-    {
-        return array_slice($this->getAncestors(), 1);
-    }
-
     /**
      * {@inheritDoc}
      */
     public function getAncestorsAndSelf()
     {
         return array_merge($this->getAncestors(), [$this]);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getAncestorsAndSelfWithoutRoot()
-    {
-        return array_slice($this->getAncestorsAndSelf(), 1);
     }
 
     /**

--- a/tests/Tree/Node/NodeTest.php
+++ b/tests/Tree/Node/NodeTest.php
@@ -150,15 +150,6 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([$root, $a, $b], $c->getAncestors());
     }
 
-    public function testGetAncestorsWithoutRoot()
-    {
-        $root = new Node('r');
-        $root->addChild($a = new Node('a'));
-        $a->addChild($b = new Node('b'));
-
-        $this->assertEquals([$a], $b->getAncestorsWithoutRoot());
-    }
-
     public function testGetAncestorsAndSelf()
     {
         $root = new Node('r');
@@ -166,15 +157,6 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $a->addChild($b = new Node('b'));
 
         $this->assertEquals([$root, $a, $b], $b->getAncestorsAndSelf());
-    }
-
-    public function testGetAncestorsAndSelfWithoutRoot()
-    {
-        $root = new Node('r');
-        $root->addChild($a = new Node('a'));
-        $a->addChild($b = new Node('b'));
-
-        $this->assertEquals([$a, $b], $b->getAncestorsAndSelfWithoutRoot());
     }
 
     public function testGetNeighbors()


### PR DESCRIPTION
Nicolò, I'm sending along a few accessors I've found handy using other database-driven tree implementations.  This also adds a test for `getNeighbors` and a **small** change to the `getNeighbors` implementation to reset returned array indexes to start with zero.  Check the commit-message for more information about that change!

I've got 3-4 more of these to do tonight and I'm going to start focusing on handy methods for manipulating the tree.  These were just low-hanging fruit! :smile: 

I'll also update repository docs with these additions.

Hope all is well.
