### PR TITLE
Don't setChildren if no children to set

### DIFF
--- a/src/Tree/Node/NodeTrait.php
+++ b/src/Tree/Node/NodeTrait.php
@@ -39,7 +39,9 @@ trait NodeTrait
     public function __construct($value = null, array $children = [])
     {
         $this->setValue($value);
-        $this->setChildren($children);
+        if (!empty($children)) {
+            $this->setChildren($children);
+        }
     }
 
     /**


### PR DESCRIPTION
This saves an allocation (from setChildren resetting `$this->children` to an empty array) and a decent amount of time during construction (from not allocating and not calling various functions).