### PR TITLE
Enhancement: Implement pre- and post-order walkers

### DIFF
--- a/src/Visitor/PostOrderVisitor.php
+++ b/src/Visitor/PostOrderVisitor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tree\Visitor;
+
+use Tree\Node\NodeInterface;
+
+class PostOrderVisitor implements Visitor
+{
+    public function visit(NodeInterface $node)
+    {
+        $nodes = [];
+
+        foreach ($node->getChildren() as $child) {
+            $nodes = array_merge(
+                $nodes,
+                $child->accept($this)
+            );
+        }
+
+        $nodes[] = $node;
+
+        return $nodes;
+    }
+}

--- a/src/Visitor/PreOrderVisitor.php
+++ b/src/Visitor/PreOrderVisitor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tree\Visitor;
+
+use Tree\Node\NodeInterface;
+
+class PreOrderVisitor implements Visitor
+{
+    public function visit(NodeInterface $node)
+    {
+        $nodes = [
+            $node,
+        ];
+
+        foreach ($node->getChildren() as $child) {
+            $nodes = array_merge(
+                $nodes,
+                $child->accept($this)
+            );
+        }
+
+        return $nodes;
+    }
+}

--- a/tests/Visitor/PostOrderVisitorTest.php
+++ b/tests/Visitor/PostOrderVisitorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tree\Test\Visitor;
+
+use Tree\Node\Node;
+use Tree\Visitor\PostOrderVisitor;
+
+class PostOrderVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsInterface()
+    {
+        $visitor = new PostOrderVisitor();
+
+        $this->assertInstanceOf('Tree\Visitor\Visitor', $visitor);
+    }
+
+    /**
+     * root
+     */
+    public function testWalkTreeWithOneNode()
+    {
+        $root = new Node('root');
+
+        $visitor = new PostOrderVisitor();
+
+        $expected = [
+            $root,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($root));
+    }
+
+    /**
+     * root
+     *  |
+     *  a
+     */
+    public function testWalkTreeWithTwoNodes()
+    {
+        $root = new Node('root');
+
+        $a = new Node('a');
+
+        $root->addChild($a);
+
+        $visitor = new PostOrderVisitor();
+
+        $expected = [
+            $a,
+            $root,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($root));
+    }
+
+    /**
+     *    root
+     *    /|\
+     *   a b c
+     *  /| |
+     * d e f
+     */
+    public function testWalkTreeWithMoreNodes()
+    {
+        $root = new Node('root');
+
+        $a = new Node('a');
+        $b = new Node('b');
+        $c = new Node('c');
+        $d = new Node('d');
+        $e = new Node('e');
+        $f = new Node('f');
+
+        $root->addChild($a);
+        $root->addChild($b);
+        $root->addChild($c);
+
+        $a->addChild($d);
+        $a->addChild($e);
+
+        $b->addChild($f);
+
+        $visitor = new PostOrderVisitor();
+
+        $expected = [
+            $d,
+            $e,
+            $a,
+            $f,
+            $b,
+            $c,
+            $root,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($root));
+    }
+
+    /**
+     *    root
+     *    /|\
+     *   a b c
+     *  /| |
+     * d e f
+     */
+    public function testWalkSubTree()
+    {
+        $root = new Node('root');
+
+        $a = new Node('a');
+        $b = new Node('b');
+        $c = new Node('c');
+        $d = new Node('d');
+        $e = new Node('e');
+        $f = new Node('f');
+
+        $root->addChild($a);
+        $root->addChild($b);
+        $root->addChild($c);
+
+        $a->addChild($d);
+        $a->addChild($e);
+
+        $b->addChild($f);
+
+        $visitor = new PostOrderVisitor();
+
+        $expected = [
+            $d,
+            $e,
+            $a,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($a));
+    }
+}

--- a/tests/Visitor/PreOrderVisitorTest.php
+++ b/tests/Visitor/PreOrderVisitorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tree\Test\Visitor;
+
+use Tree\Node\Node;
+use Tree\Visitor\PreOrderVisitor;
+
+class PreOrderVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsInterface()
+    {
+        $visitor = new PreOrderVisitor();
+
+        $this->assertInstanceOf('Tree\Visitor\Visitor', $visitor);
+    }
+
+    /**
+     * root
+     */
+    public function testWalkTreeWithOneNode()
+    {
+        $root = new Node('root');
+
+        $visitor = new PreOrderVisitor();
+
+        $expected = [
+            $root,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($root));
+    }
+
+    /**
+     * root
+     *  |
+     *  a
+     */
+    public function testWalkTreeWithTwoNodes()
+    {
+        $root = new Node('root');
+
+        $a = new Node('a');
+
+        $root->addChild($a);
+
+        $visitor = new PreOrderVisitor();
+
+        $expected = [
+            $root,
+            $a,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($root));
+    }
+
+    /**
+     *    root
+     *    /|\
+     *   a b c
+     *  /| |
+     * d e f
+     */
+    public function testWalkTreeWithMoreNodes()
+    {
+        $root = new Node('root');
+
+        $a = new Node('a');
+        $b = new Node('b');
+        $c = new Node('c');
+        $d = new Node('d');
+        $e = new Node('e');
+        $f = new Node('f');
+
+        $root->addChild($a);
+        $root->addChild($b);
+        $root->addChild($c);
+
+        $a->addChild($d);
+        $a->addChild($e);
+
+        $b->addChild($f);
+
+        $visitor = new PreOrderVisitor();
+
+        $expected = [
+            $root,
+            $a,
+            $d,
+            $e,
+            $b,
+            $f,
+            $c,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($root));
+    }
+
+    /**
+     *    root
+     *    /|\
+     *   a b c
+     *  /| |
+     * d e f
+     */
+    public function testWalkSubTree()
+    {
+        $root = new Node('root');
+
+        $a = new Node('a');
+        $b = new Node('b');
+        $c = new Node('c');
+        $d = new Node('d');
+        $e = new Node('e');
+        $f = new Node('f');
+
+        $root->addChild($a);
+        $root->addChild($b);
+        $root->addChild($c);
+
+        $a->addChild($d);
+        $a->addChild($e);
+
+        $b->addChild($f);
+
+        $visitor = new PreOrderVisitor();
+
+        $expected = [
+            $a,
+            $d,
+            $e,
+        ];
+
+        $this->assertSame($expected, $visitor->visit($a));
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that a `Tree\Visitor\PreOrderVisitor` walks a tree in pre-order
* [x] asserts that a `Tree\Visitor\PostOrderVisitor` walks a tree in post-order

Follows https://twitter.com/localheinz/status/633893849392377856.

![Walking it](https://cloud.githubusercontent.com/assets/605483/9359885/831a0ede-4693-11e5-9c26-0110c3f44fd7.jpg)
