### PR TITLE
Add check for isTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ $node->setChildren([new Node('foo'), new Node('bar')]);
 $node->removeAllChildren();
 ```
 
-### Getting if the node is a tree or not
-A tree is a node with one or more children.
+### Getting if the node is an internal node (sub-tree) or not
+An internal node is a non-root node with one or more children.
 ```php
-$node->isTree();
+$node->isInternalNode();
 ```
 
 ### Getting if the node is a leaf or not

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ $node->setChildren([new Node('foo'), new Node('bar')]);
 $node->removeAllChildren();
 ```
 
+### Getting if the node is a tree or not
+A tree is a node with one or more children.
+```php
+$node->isTree();
+```
+
 ### Getting if the node is a leaf or not
 A leaf is a node with no children.
 ```php

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $node->removeAllChildren();
 ```
 
 ### Getting if the node is an internal node (sub-tree) or not
-An internal node is a non-root node with one or more children.
+An internal node is root or a non-leaf node.
 ```php
 $node->isInternalNode();
 ```

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -141,6 +141,13 @@ interface NodeInterface
     public function isLeaf();
 
     /**
+     * Return true if the node has children, false otherwise
+     *
+     * @return bool
+     */
+    public function isTree();
+
+    /**
      * Return the distance from the current node to the root
      *
      * @return int

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -141,7 +141,7 @@ interface NodeInterface
     public function isLeaf();
 
     /**
-     * Return true if the node has children, false otherwise
+     * Return true if the node is not a leaf, false otherwise
      *
      * @return bool
      */

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -145,7 +145,7 @@ interface NodeInterface
      *
      * @return bool
      */
-    public function isTree();
+    public function isInternalNode();
 
     /**
      * Return the distance from the current node to the root

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -195,7 +195,7 @@ trait NodeTrait
      */
     public function isLeaf()
     {
-        return count($this->children) === 0;
+        return !$this->isRoot() && count($this->children) === 0;
     }
 
     /**
@@ -203,7 +203,7 @@ trait NodeTrait
      */
     public function isInternalNode()
     {
-        return !$this->isRoot() && !$this->isLeaf();
+        return !$this->isLeaf();
     }
 
     /**

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -199,6 +199,14 @@ trait NodeTrait
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function isTree()
+    {
+        return count($this->children) > 0;
+    }
+
+    /**
      * @return bool
      */
     public function isRoot()

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -201,9 +201,9 @@ trait NodeTrait
     /**
      * {@inheritDoc}
      */
-    public function isTree()
+    public function isInternalNode()
     {
-        return count($this->children) > 0;
+        return !$this->isRoot() && !$this->isLeaf();
     }
 
     /**
@@ -300,4 +300,4 @@ trait NodeTrait
         foreach ($this->getChildren() as $child)
             $child->setParent(null);
     }
-} 
+}

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -220,21 +220,20 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($root->isChild());
     }
 
-    public function testIsTree()
+    public function testIsInternalNode()
     {
         $root = new Node('root');
 
-        $this->assertFalse($root->isTree());
+        $this->assertFalse($root->isInternalNode(), "A root without children is an external node");
 
         $subTree = new Node('subTree');
         $subTree->addChild($child = new Node('child'));
 
         $root->addChild($subTree);
 
-        $this->assertTrue($root->isTree());
-        $this->assertTrue($subTree->isTree());
-        $this->assertFalse($child->isTree());
-        $this->assertFalse($subTree->isLeaf());
+        $this->assertTrue($subTree->isInternalNode(), "A sub-tree is an internal node");
+        $this->assertFalse($child->isInternalNode(), "An empty sub-node (a leaf) is not an internal node");
+        $this->assertFalse($subTree->isLeaf(), "An internal node is not a leaf");
     }
 
     public function testGetDepth()

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -185,11 +185,11 @@ class NodeTest extends \PHPUnit_Framework_TestCase
     {
         $root = new Node;
 
-        $this->assertTrue($root->isLeaf());
-
-        $root->addChild(new Node('child'));
-
         $this->assertFalse($root->isLeaf());
+
+        $root->addChild($child = new Node('child'));
+
+        $this->asserttrue($child->isLeaf());
     }
 
     public function testRoot()
@@ -224,7 +224,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
     {
         $root = new Node('root');
 
-        $this->assertFalse($root->isInternalNode(), "A root without children is an external node");
+        $this->assertTrue($root->isInternalNode(), "A root without children is still an internal node");
 
         $subTree = new Node('subTree');
         $subTree->addChild($child = new Node('child'));

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -220,6 +220,23 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($root->isChild());
     }
 
+    public function testIsTree()
+    {
+        $root = new Node('root');
+
+        $this->assertFalse($root->isTree());
+
+        $subTree = new Node('subTree');
+        $subTree->addChild($child = new Node('child'));
+
+        $root->addChild($subTree);
+
+        $this->assertTrue($root->isTree());
+        $this->assertTrue($subTree->isTree());
+        $this->assertFalse($child->isTree());
+        $this->assertFalse($subTree->isLeaf());
+    }
+
     public function testGetDepth()
     {
         $root = new Node;

--- a/tests/Visitor/YieldVisitorTest.php
+++ b/tests/Visitor/YieldVisitorTest.php
@@ -44,7 +44,8 @@ class YieldVisitorTest extends \PHPUnit_Framework_TestCase
 
     public function testTheYieldOfALeafNodeIsTheNodeItself()
     {
-        $node = new Node('node');
+        $root = new Node('root');
+        $root->addChild($node = new Node('node'));
         $visitor = new YieldVisitor;
 
         $this->assertEquals([$node], $node->accept($visitor));


### PR DESCRIPTION
This is an explicit check to see if the node is a tree or sub-tree. One could argue that
if the node is not a leaf, it is implicitly a tree. Yet, checking for `!$node->isLeaf()`
is an odd way to see if the node has children.

This paves the way to ask if this node is a tree & a root? a tree & a sub-tree? or a leaf?