### PR TITLE
Enhancement: Enforce PSR-2 with fabpot/php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
+.php_cs.cache
 phpunit.xml

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,25 @@
+<?php
+
+$header = <<<EOF
+This file is part of Tree.
+
+(c) 2013-2015 Nicolò Martini
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF;
+
+Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(__DIR__)
+;
+
+return Symfony\CS\Config\Config::create()
+    ->setUsingCache(true)
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers([
+        'header_comment',
+    ])
+    ->finder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_script:
 
 script:
   - phpunit
+  - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+cs:
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
         "psr-4": {
             "Tree\\Test\\": "tests/"
         }
+    },
+    "require-dev": {
+        "fabpot/php-cs-fixer": "^1.10"
     }
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,427 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c390d79a97a7207157bdab1c1fbb9417",
+    "hash": "0eaf593a551250a75772c888c2c904a0",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "fabpot/php-cs-fixer",
+            "version": "v1.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "8e21b4fb32c4618a425817d9f0daf3d57a9808d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/8e21b4fb32c4618a425817d9f0daf3d57a9808d1",
+                "reference": "8e21b4fb32c4618a425817d9f0daf3d57a9808d1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.3",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/filesystem": "~2.1",
+                "symfony/finder": "~2.1",
+                "symfony/process": "~2.3",
+                "symfony/stopwatch": "~2.5"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "0.7.*@dev"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2015-07-27 20:56:10"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-02-22 15:13:53"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/d6cf02fe73634c96677e428f840704bfbcaec29e",
+                "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-28 15:18:12"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-18 19:21:56"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-09 16:07:40"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Finder.git",
+                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/ae0f363277485094edc04c9f3cbe595b183b78e4",
+                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-09 16:07:40"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Process.git",
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/48aeb0e48600321c272955132d7606ab0a49adb3",
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-01 11:25:50"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Stopwatch.git",
+                "reference": "b07a866719bbac5294c67773340f97b871733310"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/b07a866719bbac5294c67773340f97b871733310",
+                "reference": "b07a866719bbac5294c67773340f97b871733310",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-07-01 18:23:16"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/src/Builder/NodeBuilder.php
+++ b/src/Builder/NodeBuilder.php
@@ -1,8 +1,9 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Builder/NodeBuilderInterface.php
+++ b/src/Builder/NodeBuilderInterface.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
- * This file is part of library-template.
+ * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Builder;
 
 use Tree\Node\NodeInterface;
@@ -88,4 +90,3 @@ interface NodeBuilderInterface
      */
     public function nodeInstanceByValue($value = null);
 }
-

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -1,8 +1,9 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
- * This file is part of Tree library.
+ * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Node;
 
 use Tree\Visitor\Visitor;

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 /**
  * This file is part of Tree
  *
@@ -223,8 +233,9 @@ trait NodeTrait
     {
         $node = $this;
 
-        while ($parent = $node->getParent())
+        while ($parent = $node->getParent()) {
             $node = $parent;
+        }
 
         return $node;
     }
@@ -289,7 +300,8 @@ trait NodeTrait
 
     private function removeParentFromChildren()
     {
-        foreach ($this->getChildren() as $child)
+        foreach ($this->getChildren() as $child) {
             $child->setParent(null);
+        }
     }
-} 
+}

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of Tree
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- *
- * @author Nicolò Martini <nicmartnic@gmail.com>
- */
-
 namespace Tree\Node;
 
 use Tree\Visitor\Visitor;

--- a/src/Visitor/PostOrderVisitor.php
+++ b/src/Visitor/PostOrderVisitor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;

--- a/src/Visitor/PreOrderVisitor.php
+++ b/src/Visitor/PreOrderVisitor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;

--- a/src/Visitor/Visitor.php
+++ b/src/Visitor/Visitor.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
- * This file is part of Tree library.
+ * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;

--- a/src/Visitor/YieldVisitor.php
+++ b/src/Visitor/YieldVisitor.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of Tree
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- *
- * @author Nicolò Martini <nicmartnic@gmail.com>
- */
-
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;

--- a/src/Visitor/YieldVisitor.php
+++ b/src/Visitor/YieldVisitor.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 /**
  * This file is part of Tree
  *
@@ -9,7 +19,6 @@
  */
 
 namespace Tree\Visitor;
-
 
 use Tree\Node\NodeInterface;
 
@@ -37,4 +46,4 @@ class YieldVisitor implements Visitor
 
         return $yield;
     }
-} 
+}

--- a/tests/Builder/NodeBuilderTest.php
+++ b/tests/Builder/NodeBuilderTest.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Test\Builder;
 
 use Tree\Node\Node;
@@ -15,7 +17,7 @@ use Tree\Builder\NodeBuilder;
 /**
  * Unit tests for class FirstClass
  */
-class NodeTest extends \PHPUnit_Framework_TestCase
+class NodeBuilderTest extends \PHPUnit_Framework_TestCase
 {
     /** @var NodeBuilder */
     protected $builder;
@@ -131,7 +133,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
      */
     private function childrenValues(array $children)
     {
-        return array_map(function(Node $node) {
+        return array_map(function (Node $node) {
             return $node->getValue();
         }, $children);
     }

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
- * (c) 2013 Nicolò Martini
+ * (c) 2013-2015 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Test\Tree;
 
 use Tree\Node\Node;
@@ -18,7 +20,6 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-
     }
 
     public function testSetValue()
@@ -81,16 +82,16 @@ class NodeTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testSetChildrenSetParentsReferences()
-     {
-         $root = new Node;
-         $root
+    {
+        $root = new Node;
+        $root
              ->addChild($child1 = new Node('child1'))
              ->addChild($child2 = new Node('child2'))
          ;
 
-         $this->assertEquals($root, $child1->getParent());
-         $this->assertEquals($root, $child2->getParent());
-     }
+        $this->assertEquals($root, $child1->getParent());
+        $this->assertEquals($root, $child2->getParent());
+    }
 
     public function testRemoveChild()
     {

--- a/tests/Visitor/PostOrderVisitorTest.php
+++ b/tests/Visitor/PostOrderVisitorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Test\Visitor;
 
 use Tree\Node\Node;

--- a/tests/Visitor/PreOrderVisitorTest.php
+++ b/tests/Visitor/PreOrderVisitorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Test\Visitor;
 
 use Tree\Node\Node;

--- a/tests/Visitor/YieldVisitorTest.php
+++ b/tests/Visitor/YieldVisitorTest.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of Tree
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- *
- * @author Nicolò Martini <nicmartnic@gmail.com>
- */
-
 namespace Tree\Test\Visitor;
 
 use Tree\Node\Node;

--- a/tests/Visitor/YieldVisitorTest.php
+++ b/tests/Visitor/YieldVisitorTest.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013-2015 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 /**
  * This file is part of Tree
  *


### PR DESCRIPTION
This PR
- [x] requires [`fabpot/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer)
- [x] adds a simple configuration using PSR-2 (and adding a header comment)
- [x] adds a `Makefile` with a `cs` target
- [x] runs `php-cs-fixer` on Travis
- [x] runs `make cs` to fix the build
