### PR TITLE
Fix: Remove empty setUp()

### DIFF
--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -16,11 +16,6 @@ use Tree\Node\Node;
  */
 class NodeTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-
-    }
-
     public function testSetValue()
     {
         $node = new Node;


### PR DESCRIPTION
This PR

* [x] removes an empty `setUp()` from a test