### PR TITLE
Variant to Node, constructor is in the Node class instead of Trait

### DIFF
--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -16,4 +16,16 @@ namespace Tree\Node;
 class Node implements NodeInterface
 {
     use NodeTrait;
+
+    /**
+     * @param mixed $value
+     * @param NodeInterface[] $children
+     */
+    public function __construct($value = null, array $children = [])
+    {
+        $this->setValue($value);
+        if (!empty($children)) {
+            $this->setChildren($children);
+        }
+    }
 }

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -33,18 +33,6 @@ trait NodeTrait
     private $children = [];
 
     /**
-     * @param mixed $value
-     * @param NodeInterface[] $children
-     */
-    public function __construct($value = null, array $children = [])
-    {
-        $this->setValue($value);
-        if (!empty($children)) {
-            $this->setChildren($children);
-        }
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function setValue($value)


### PR DESCRIPTION
This is a Variant to your Tree project, where the constructor is in the Node class rather than in the Trait.

This allows for other classes implementing the NodeInterface, to be able to use the NodeTrait but have a different constructor that suits that Node behavior/requirements (i.e. Have more attributes than just value, and constructor requires all of them).
