### PR TITLE
Fix: Increase versions in composer.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     package-ecosystem: "composer"
     schedule:
       interval: "daily"
+    versioning-strategy: "increase"
 
   - commit-message:
       include: "scope"


### PR DESCRIPTION
This PR

* [x] configures Dependabot to increase versions in `composer.json`