### PR TITLE
Enhancement: Require and use ergebnis/php-cs-fixer-config

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,9 +11,11 @@ For details, take a look at the following workflow configuration files:
 
 We are using [`ergebnis/composer-normalize`](https://github.com/ergebnis/composer-normalize) to normalize `composer.json`.
 
+We are using [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to enforce coding standards in PHP files.
+
 Run
 
-```
+```sh
 $ make coding-standards
 ```
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -46,12 +46,33 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
+      - name: "Install lowest dependencies from composer.json"
+        if: "matrix.dependencies == 'lowest'"
+        run: "composer update --no-interaction --no-progress --no-suggest --prefer-lowest"
+
       - name: "Install locked dependencies from composer.lock"
         if: "matrix.dependencies == 'locked'"
         run: "composer install --no-interaction --no-progress --no-suggest"
 
+      - name: "Install highest dependencies from composer.json"
+        if: "matrix.dependencies == 'highest'"
+        run: "composer update --no-interaction --no-progress --no-suggest"
+
       - name: "Run ergebnis/composer-normalize"
         run: "composer normalize --dry-run"
+
+      - name: "Create cache directory for friendsofphp/php-cs-fixer"
+        run: "mkdir -p .build/php-cs-fixer"
+
+      - name: "Cache cache directory for friendsofphp/php-cs-fixer"
+        uses: "actions/cache@v2"
+        with:
+          path: ".build/php-cs-fixer"
+          key: "php-${{ matrix.php-version }}-php-cs-fixer-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
+
+      - name: "Run friendsofphp/php-cs-fixer"
+        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --verbose"
 
   tests:
     name: "Tests"
@@ -90,9 +111,17 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
+      - name: "Install lowest dependencies from composer.json"
+        if: "matrix.dependencies == 'lowest'"
+        run: "composer update --no-interaction --no-progress --no-suggest --prefer-lowest"
+
       - name: "Install locked dependencies from composer.lock"
         if: "matrix.dependencies == 'locked'"
         run: "composer install --no-interaction --no-progress --no-suggest"
+
+      - name: "Install highest dependencies from composer.json"
+        if: "matrix.dependencies == 'highest'"
+        run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "Run tests with phpunit/phpunit"
         run: "vendor/bin/phpunit --configuration=phpunit.xml.dist"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-vendor/
-phpunit.xml
+/.build/
+/vendor/
+/phpunit.xml

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,38 @@
+<?php
+
+use Ergebnis\PhpCsFixer;
+use PhpCsFixer\Fixer;
+
+$header = <<<'TXT'
+This file is part of Tree.
+
+(c) 2013 Nicolò Martini
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+TXT;
+
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php71(), [
+    'declare_strict_types' => false,
+    'final_class' => false,
+    'header_comment' => [
+        'comment_type' => Fixer\Comment\HeaderCommentFixer::HEADER_COMMENT,
+        'header' => \trim($header),
+        'location' => 'after_declare_strict',
+        'separate' => 'both',
+    ],
+    'void_return' => false,
+]);
+
+$config->getFinder()
+    ->ignoreDotFiles(false)
+    ->in(__DIR__)
+    ->exclude([
+        '.build/',
+        '.github/',
+    ])
+    ->name('.php_cs');
+
+$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.cache');
+
+return $config;

--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Ergebnis\PhpCsFixer;
 use PhpCsFixer\Fixer;
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@
 it: coding-standards tests ## Runs the coding-standards and tests target
 
 .PHONY: coding-standards
-coding-standards: vendor ## Normalizes composer.json with ergebnis/composer-normalize
+coding-standards: vendor ## Normalizes composer.json with ergebnis/composer-normalize and fixes code style issues with friendsofphp/php-cs-fixer
 	composer normalize
+	mkdir -p .build/php-cs-fixer
+	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
 
 .PHONY: help
 help: ## Displays this list of targets with descriptions

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.5.1",
+        "ergebnis/php-cs-fixer-config": "^2.2.0",
         "phpunit/phpunit": "^7.5.20"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,197 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4a177f60000d99dad0afa99ece9a540",
+    "content-hash": "a8e8d1a70ab829cb400dcb2463a32ffd",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "composer/semver",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2020-01-13T12:06:48+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-04T11:16:35+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "5db60a4969eba0e0c197a19c077780aadbc43c5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5db60a4969eba0e0c197a19c077780aadbc43c5d",
+                "reference": "5db60a4969eba0e0c197a19c077780aadbc43c5d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^7.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2020-05-25T17:24:27+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.3.1",
@@ -76,6 +264,66 @@
                 }
             ],
             "time": "2020-05-29T17:27:14+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "time": "2019-06-08T11:03:04+00:00"
         },
         {
             "name": "ergebnis/composer-normalize",
@@ -294,6 +542,181 @@
             "time": "2019-12-19T14:42:54+00:00"
         },
         {
+            "name": "ergebnis/php-cs-fixer-config",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/php-cs-fixer-config.git",
+                "reference": "208b4f0c700c152fdcaf5520fde38947ab1f176c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/php-cs-fixer-config/zipball/208b4f0c700c152fdcaf5520fde38947ab1f176c",
+                "reference": "208b4f0c700c152fdcaf5520fde38947ab1f176c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "friendsofphp/php-cs-fixer": "~2.16.3",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.5.1",
+                "ergebnis/license": "~1.0.0",
+                "ergebnis/phpstan-rules": "~0.15.0",
+                "ergebnis/test-util": "~1.0.0",
+                "infection/infection": "~0.13.6",
+                "jangregor/phpstan-prophecy": "~0.8.0",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "~0.12.30",
+                "phpstan/phpstan-deprecation-rules": "~0.12.4",
+                "phpstan/phpstan-phpunit": "~0.12.11",
+                "phpstan/phpstan-strict-rules": "~0.12.2",
+                "phpunit/phpunit": "^7.5.20",
+                "psalm/plugin-phpunit": "~0.10.1",
+                "symfony/filesystem": "^4.4.0",
+                "vimeo/psalm": "^3.12.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\PhpCsFixer\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
+            "homepage": "https://github.com/ergebnis/php-cs-fixer-config",
+            "funding": [
+                {
+                    "url": "https://cottonbureau.com/people/andreas-moller",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://paypal.me/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.buymeacoffee.com/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-06-23T09:27:56+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.16.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "83baf823a33a1cbd5416c8626935cf3f843c10b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/83baf823a33a1cbd5416c8626935cf3f843c10b0",
+                "reference": "83baf823a33a1cbd5416c8626935cf3f843c10b0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "composer/xdebug-handler": "^1.2",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || ^7.0",
+                "php-cs-fixer/diff": "^1.3",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.2",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.1",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+                "phpunitgoodpractices/traits": "^1.8",
+                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationCaseFactory.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/Test/IntegrationCaseFactoryInterface.php",
+                    "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/Test/IsIdenticalConstraint.php",
+                    "tests/TestCase.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-15T18:51:10+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "5.2.10",
             "source": {
@@ -459,6 +882,51 @@
             "time": "2020-01-17T21:11:47+00:00"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "1.0.3",
             "source": {
@@ -559,6 +1027,57 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1106,6 +1625,102 @@
                 "xunit"
             ],
             "time": "2020-01-08T08:45:45+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1674,6 +2289,434 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "326b064d804043005526f5a0494cfb49edb59bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/326b064d804043005526f5a0494cfb49edb59bb0",
+                "reference": "326b064d804043005526f5a0494cfb49edb59bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-30T20:06:45+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "a5370aaa7807c7a439b21386661ffccf3dff2866"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a5370aaa7807c7a439b21386661ffccf3dff2866",
+                "reference": "a5370aaa7807c7a439b21386661ffccf3dff2866",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-20T08:37:50+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-09-17T09:54:03+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "b27f491309db5757816db672b256ea2e03677d30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b27f491309db5757816db672b256ea2e03677d30",
+                "reference": "b27f491309db5757816db672b256ea2e03677d30",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-30T18:50:54+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "5729f943f9854c5781984ed4907bbb817735776b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5729f943f9854c5781984ed4907bbb817735776b",
+                "reference": "5729f943f9854c5781984ed4907bbb817735776b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T16:54:36+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "73e1d0fe11ffceb7b7d4ca55b7381cd7ce0bac05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/73e1d0fe11ffceb7b7d4ca55b7381cd7ce0bac05",
+                "reference": "73e1d0fe11ffceb7b7d4ca55b7381cd7ce0bac05",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-23T12:09:32+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.17.1",
             "source": {
@@ -1748,6 +2791,570 @@
                 }
             ],
             "time": "2020-06-06T08:46:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "7110338d81ce1cbc3e273136e4574663627037a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7110338d81ce1cbc3e273136e4574663627037a7",
+                "reference": "7110338d81ce1cbc3e273136e4574663627037a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "471b096aede7025bace8eb356b9ac801aaba7e2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/471b096aede7025bace8eb356b9ac801aaba7e2d",
+                "reference": "471b096aede7025bace8eb356b9ac801aaba7e2d",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0|~9.99",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "f048e612a3905f34931127360bdd2def19a5e582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/f048e612a3905f34931127360bdd2def19a5e582",
+                "reference": "f048e612a3905f34931127360bdd2def19a5e582",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-12T16:47:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fa0837fe02d617d31fbb25f990655861bb27bd1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fa0837fe02d617d31fbb25f990655861bb27bd1a",
+                "reference": "fa0837fe02d617d31fbb25f990655861bb27bd1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4a5b6bba3259902e386eb80dd1956181ee90b5b2",
+                "reference": "4a5b6bba3259902e386eb80dd1956181ee90b5b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:46:27+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "c714958428a85c86ab97e3a0c96db4c4f381b7f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c714958428a85c86ab97e3a0c96db4c4f381b7f5",
+                "reference": "c714958428a85c86ab97e3a0c96db4c4f381b7f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-30T20:06:45+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v1.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
+                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-10-14T12:27:06+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "f51fb90df1154a7f75987198a9689e28f91e6a50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f51fb90df1154a7f75987198a9689e28f91e6a50",
+                "reference": "f51fb90df1154a7f75987198a9689e28f91e6a50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-20T08:37:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Builder/NodeBuilder.php
+++ b/src/Builder/NodeBuilder.php
@@ -24,17 +24,11 @@ class NodeBuilder implements NodeBuilderInterface
      */
     private $nodeStack = [];
 
-    /**
-     * @param NodeInterface $node
-     */
     public function __construct(?NodeInterface $node = null)
     {
         $this->setNode($node ?: $this->nodeInstanceByValue());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setNode(NodeInterface $node)
     {
         $this
@@ -44,17 +38,11 @@ class NodeBuilder implements NodeBuilderInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNode()
     {
         return $this->nodeStack[\count($this->nodeStack) - 1];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function leaf($value = null)
     {
         $this->getNode()->addChild(
@@ -64,9 +52,6 @@ class NodeBuilder implements NodeBuilderInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function leafs($value1 /*,  $value2, ... */)
     {
         foreach (\func_get_args() as $value) {
@@ -76,9 +61,6 @@ class NodeBuilder implements NodeBuilderInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function tree($value = null)
     {
         $node = $this->nodeInstanceByValue($value);
@@ -88,9 +70,6 @@ class NodeBuilder implements NodeBuilderInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function end()
     {
         $this->popNode();
@@ -98,17 +77,11 @@ class NodeBuilder implements NodeBuilderInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function nodeInstanceByValue($value = null)
     {
         return new Node($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function value($value)
     {
         $this->getNode()->setValue($value);

--- a/src/Builder/NodeBuilder.php
+++ b/src/Builder/NodeBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
@@ -10,11 +11,11 @@
 
 namespace Tree\Builder;
 
-use Tree\Node\NodeInterface;
 use Tree\Node\Node;
+use Tree\Node\NodeInterface;
 
 /**
- * Main implementation of the NodeBuilderInterface
+ * Main implementation of the NodeBuilderInterface.
  */
 class NodeBuilder implements NodeBuilderInterface
 {
@@ -26,7 +27,7 @@ class NodeBuilder implements NodeBuilderInterface
     /**
      * @param NodeInterface $node
      */
-    public function __construct(NodeInterface $node = null)
+    public function __construct(?NodeInterface $node = null)
     {
         $this->setNode($node ?: $this->nodeInstanceByValue());
     }
@@ -38,8 +39,7 @@ class NodeBuilder implements NodeBuilderInterface
     {
         $this
             ->emptyStack()
-            ->pushNode($node)
-        ;
+            ->pushNode($node);
 
         return $this;
     }
@@ -49,7 +49,7 @@ class NodeBuilder implements NodeBuilderInterface
      */
     public function getNode()
     {
-        return $this->nodeStack[count($this->nodeStack) - 1];
+        return $this->nodeStack[\count($this->nodeStack) - 1];
     }
 
     /**
@@ -69,7 +69,7 @@ class NodeBuilder implements NodeBuilderInterface
      */
     public function leafs($value1 /*,  $value2, ... */)
     {
-        foreach (func_get_args() as $value) {
+        foreach (\func_get_args() as $value) {
             $this->leaf($value);
         }
 
@@ -125,13 +125,13 @@ class NodeBuilder implements NodeBuilderInterface
 
     private function pushNode(NodeInterface $node)
     {
-        array_push($this->nodeStack, $node);
+        \array_push($this->nodeStack, $node);
 
         return $this;
     }
 
     private function popNode()
     {
-        return array_pop($this->nodeStack);
+        return \array_pop($this->nodeStack);
     }
 }

--- a/src/Builder/NodeBuilderInterface.php
+++ b/src/Builder/NodeBuilderInterface.php
@@ -16,7 +16,7 @@ use Tree\Node\NodeInterface;
 /**
  * Interface that allows a fluent tree building.
  *
- * @author     Nicolò Martini <nicmartnic@gmail.com>
+ * @author Nicolò Martini <nicmartnic@gmail.com>
  */
 interface NodeBuilderInterface
 {

--- a/src/Builder/NodeBuilderInterface.php
+++ b/src/Builder/NodeBuilderInterface.php
@@ -1,12 +1,14 @@
 <?php
+
 /*
- * This file is part of library-template.
+ * This file is part of Tree.
  *
  * (c) 2013 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Builder;
 
 use Tree\Node\NodeInterface;
@@ -14,13 +16,12 @@ use Tree\Node\NodeInterface;
 /**
  * Interface that allows a fluent tree building.
  *
- * @package    Tree
  * @author     Nicolò Martini <nicmartnic@gmail.com>
  */
 interface NodeBuilderInterface
 {
     /**
-     * Set the node the builder will manage
+     * Set the node the builder will manage.
      *
      * @param NodeInterface $node
      *
@@ -29,14 +30,14 @@ interface NodeBuilderInterface
     public function setNode(NodeInterface $node);
 
     /**
-     * Get the node the builder manages
+     * Get the node the builder manages.
      *
      * @return NodeInterface
      */
     public function getNode();
 
     /**
-     * Set the value of the underlaying node
+     * Set the value of the underlaying node.
      *
      * @param mixed $value
      *
@@ -45,7 +46,7 @@ interface NodeBuilderInterface
     public function value($value);
 
     /**
-     * Add a leaf to the node
+     * Add a leaf to the node.
      *
      * @param mixed $value The value of the leaf node
      *
@@ -54,7 +55,7 @@ interface NodeBuilderInterface
     public function leaf($value = null);
 
     /**
-     * Add several leafs to the node
+     * Add several leafs to the node.
      *
      * @param $value, ... An arbitrary long list of values
      *
@@ -63,7 +64,7 @@ interface NodeBuilderInterface
     public function leafs($value);
 
     /**
-     * Add a child to the node enter in its scope
+     * Add a child to the node enter in its scope.
      *
      * @param null $value
      *
@@ -72,7 +73,7 @@ interface NodeBuilderInterface
     public function tree($value = null);
 
     /**
-     * Goes up to the parent node context
+     * Goes up to the parent node context.
      *
      * @return null|NodeBuilderInterface A NodeBuilderInterface instanced linked to the parent node
      */
@@ -80,7 +81,7 @@ interface NodeBuilderInterface
 
     /**
      * Return a node instance set with the given value. Implementation can follow their own logic
-     * in choosing the NodeInterface implmentation taking into account the value
+     * in choosing the NodeInterface implmentation taking into account the value.
      *
      * @param mixed $value
      *
@@ -88,4 +89,3 @@ interface NodeBuilderInterface
      */
     public function nodeInstanceByValue($value = null);
 }
-

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -11,9 +11,6 @@
 
 namespace Tree\Node;
 
-/**
- * Class Node.
- */
 class Node implements NodeInterface
 {
     use NodeTrait;

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
@@ -11,19 +12,20 @@
 namespace Tree\Node;
 
 /**
- * Class Node
+ * Class Node.
  */
 class Node implements NodeInterface
 {
     use NodeTrait;
 
     /**
-     * @param mixed $value
+     * @param mixed           $value
      * @param NodeInterface[] $children
      */
     public function __construct($value = null, array $children = [])
     {
         $this->setValue($value);
+
         if (!empty($children)) {
             $this->setChildren($children);
         }

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -16,7 +16,7 @@ use Tree\Visitor\Visitor;
 /**
  * Interface for tree nodes.
  *
- * @author     Nicolò Martini <nicmartnic@gmail.com>
+ * @author Nicolò Martini <nicmartnic@gmail.com>
  */
 interface NodeInterface
 {
@@ -78,14 +78,14 @@ interface NodeInterface
     public function setChildren(array $children);
 
     /**
-     * setParent.
+     * Set the parent node.
      *
      * @param NodeInterface $parent
      */
     public function setParent(?self $parent = null);
 
     /**
-     * getParent.
+     * Return the parent node.
      *
      * @return NodeInterface
      */

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -1,26 +1,27 @@
 <?php
+
 /*
- * This file is part of Tree library.
+ * This file is part of Tree.
  *
  * (c) 2013 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Node;
 
 use Tree\Visitor\Visitor;
 
 /**
- * Interface for tree nodes
+ * Interface for tree nodes.
  *
- * @package    Tree
  * @author     Nicolò Martini <nicmartnic@gmail.com>
  */
 interface NodeInterface
 {
     /**
-     * Set the value of the current node
+     * Set the value of the current node.
      *
      * @param mixed $value
      *
@@ -29,46 +30,46 @@ interface NodeInterface
     public function setValue($value);
 
     /**
-     * Get the current node value
+     * Get the current node value.
      *
      * @return mixed
      */
     public function getValue();
 
     /**
-     * Add a child
+     * Add a child.
      *
      * @param NodeInterface $child
      *
      * @return mixed
      */
-    public function addChild(NodeInterface $child);
+    public function addChild(self $child);
 
     /**
-     * Remove a node from children
+     * Remove a node from children.
      *
      * @param NodeInterface $child
      *
      * @return NodeInterface the current instance
      */
-    public function removeChild(NodeInterface $child);
+    public function removeChild(self $child);
 
     /**
-     * Remove all children
+     * Remove all children.
      *
      * @return NodeInterface The current instance
      */
     public function removeAllChildren();
 
     /**
-     * Return the array of children
+     * Return the array of children.
      *
      * @return NodeInterface[]
      */
     public function getChildren();
 
     /**
-     * Replace the children set with the given one
+     * Replace the children set with the given one.
      *
      * @param NodeInterface[] $children
      *
@@ -77,15 +78,14 @@ interface NodeInterface
     public function setChildren(array $children);
 
     /**
-     * setParent
+     * setParent.
      *
      * @param NodeInterface $parent
-     * @return void
      */
-    public function setParent(NodeInterface $parent = null);
+    public function setParent(?self $parent = null);
 
     /**
-     * getParent
+     * getParent.
      *
      * @return NodeInterface
      */
@@ -120,7 +120,7 @@ interface NodeInterface
     public function getNeighborsAndSelf();
 
     /**
-     * Return true if the node is the root, false otherwise
+     * Return true if the node is the root, false otherwise.
      *
      * @return bool
      */
@@ -134,31 +134,30 @@ interface NodeInterface
     public function isChild();
 
     /**
-     * Return true if the node has no children, false otherwise
+     * Return true if the node has no children, false otherwise.
      *
      * @return bool
      */
     public function isLeaf();
 
     /**
-     * Return the distance from the current node to the root
+     * Return the distance from the current node to the root.
      *
      * @return int
      */
     public function getDepth();
 
     /**
-     * Return the height of the tree whose root is this node
+     * Return the height of the tree whose root is this node.
      *
      * @return int
      */
     public function getHeight();
 
     /**
-     * Accept method for the visitor pattern (see http://en.wikipedia.org/wiki/Visitor_pattern)
+     * Accept method for the visitor pattern (see http://en.wikipedia.org/wiki/Visitor_pattern).
      *
      * @param Visitor $visitor
-     * @return void
      */
     public function accept(Visitor $visitor);
 }

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -1,11 +1,12 @@
 <?php
-/**
- * This file is part of Tree
+
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @author Nicolò Martini <nicmartnic@gmail.com>
  */
 
 namespace Tree\Node;
@@ -20,10 +21,9 @@ trait NodeTrait
     private $value;
 
     /**
-     * parent
+     * parent.
      *
      * @var NodeInterface
-     * @access private
      */
     private $parent;
 
@@ -67,12 +67,12 @@ trait NodeTrait
     public function removeChild(NodeInterface $child)
     {
         foreach ($this->children as $key => $myChild) {
-            if ($child == $myChild) {
+            if ($child === $myChild) {
                 unset($this->children[$key]);
             }
         }
 
-        $this->children = array_values($this->children);
+        $this->children = \array_values($this->children);
 
         $child->setParent(null);
 
@@ -115,7 +115,7 @@ trait NodeTrait
     /**
      * {@inheritdoc}
      */
-    public function setParent(NodeInterface $parent = null)
+    public function setParent(?NodeInterface $parent = null)
     {
         $this->parent = $parent;
     }
@@ -135,8 +135,9 @@ trait NodeTrait
     {
         $parents = [];
         $node = $this;
+
         while ($parent = $node->getParent()) {
-            array_unshift($parents, $parent);
+            \array_unshift($parents, $parent);
             $node = $parent;
         }
 
@@ -144,11 +145,11 @@ trait NodeTrait
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAncestorsAndSelf()
     {
-        return array_merge($this->getAncestors(), [$this]);
+        return \array_merge($this->getAncestors(), [$this]);
     }
 
     /**
@@ -160,18 +161,18 @@ trait NodeTrait
         $current = $this;
 
         // Uses array_values to reset indexes after filter.
-        return array_values(
-            array_filter(
+        return \array_values(
+            \array_filter(
                 $neighbors,
-                function ($item) use ($current) {
-                    return $item != $current;
+                static function ($item) use ($current) {
+                    return $item !== $current;
                 }
             )
         );
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getNeighborsAndSelf()
     {
@@ -179,11 +180,11 @@ trait NodeTrait
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isLeaf()
     {
-        return count($this->children) === 0;
+        return 0 === \count($this->children);
     }
 
     /**
@@ -191,19 +192,19 @@ trait NodeTrait
      */
     public function isRoot()
     {
-        return $this->getParent() === null;
+        return null === $this->getParent();
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isChild()
     {
-        return $this->getParent() !== null;
+        return null !== $this->getParent();
     }
 
     /**
-     * Find the root of the node
+     * Find the root of the node.
      *
      * @return NodeInterface
      */
@@ -211,8 +212,9 @@ trait NodeTrait
     {
         $node = $this;
 
-        while ($parent = $node->getParent())
+        while ($parent = $node->getParent()) {
             $node = $parent;
+        }
 
         return $node;
     }
@@ -234,7 +236,7 @@ trait NodeTrait
     }
 
     /**
-     * Return the height of the tree whose root is this node
+     * Return the height of the tree whose root is this node.
      *
      * @return int
      */
@@ -250,16 +252,18 @@ trait NodeTrait
             $heights[] = $child->getHeight();
         }
 
-        return max($heights) + 1;
+        return \max($heights) + 1;
     }
 
     /**
-     * Return the number of nodes in a tree
+     * Return the number of nodes in a tree.
+     *
      * @return int
      */
     public function getSize()
     {
         $size = 1;
+
         foreach ($this->getChildren() as $child) {
             $size += $child->getSize();
         }
@@ -277,7 +281,8 @@ trait NodeTrait
 
     private function removeParentFromChildren()
     {
-        foreach ($this->getChildren() as $child)
+        foreach ($this->getChildren() as $child) {
             $child->setParent(null);
+        }
     }
-} 
+}

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -32,9 +32,6 @@ trait NodeTrait
      */
     private $children = [];
 
-    /**
-     * {@inheritdoc}
-     */
     public function setValue($value)
     {
         $this->value = $value;
@@ -42,17 +39,11 @@ trait NodeTrait
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getValue()
     {
         return $this->value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addChild(NodeInterface $child)
     {
         $child->setParent($this);
@@ -61,9 +52,6 @@ trait NodeTrait
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeChild(NodeInterface $child)
     {
         foreach ($this->children as $key => $myChild) {
@@ -79,9 +67,6 @@ trait NodeTrait
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeAllChildren()
     {
         $this->setChildren([]);
@@ -89,17 +74,11 @@ trait NodeTrait
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getChildren()
     {
         return $this->children;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setChildren(array $children)
     {
         $this->removeParentFromChildren();
@@ -112,25 +91,16 @@ trait NodeTrait
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setParent(?NodeInterface $parent = null)
     {
         $this->parent = $parent;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getParent()
     {
         return $this->parent;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAncestors()
     {
         $parents = [];
@@ -144,23 +114,16 @@ trait NodeTrait
         return $parents;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAncestorsAndSelf()
     {
         return \array_merge($this->getAncestors(), [$this]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNeighbors()
     {
         $neighbors = $this->getParent()->getChildren();
         $current = $this;
 
-        // Uses array_values to reset indexes after filter.
         return \array_values(
             \array_filter(
                 $neighbors,
@@ -171,17 +134,11 @@ trait NodeTrait
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNeighborsAndSelf()
     {
         return $this->getParent()->getChildren();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isLeaf()
     {
         return 0 === \count($this->children);
@@ -195,9 +152,6 @@ trait NodeTrait
         return null === $this->getParent();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isChild()
     {
         return null !== $this->getParent();
@@ -271,9 +225,6 @@ trait NodeTrait
         return $size;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function accept(Visitor $visitor)
     {
         return $visitor->visit($this);

--- a/src/Visitor/PostOrderVisitor.php
+++ b/src/Visitor/PostOrderVisitor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;
@@ -11,7 +20,7 @@ class PostOrderVisitor implements Visitor
         $nodes = [];
 
         foreach ($node->getChildren() as $child) {
-            $nodes = array_merge(
+            $nodes = \array_merge(
                 $nodes,
                 $child->accept($this)
             );

--- a/src/Visitor/PreOrderVisitor.php
+++ b/src/Visitor/PreOrderVisitor.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;
@@ -13,7 +22,7 @@ class PreOrderVisitor implements Visitor
         ];
 
         foreach ($node->getChildren() as $child) {
-            $nodes = array_merge(
+            $nodes = \array_merge(
                 $nodes,
                 $child->accept($this)
             );

--- a/src/Visitor/Visitor.php
+++ b/src/Visitor/Visitor.php
@@ -1,26 +1,28 @@
 <?php
+
 /*
- * This file is part of Tree library.
+ * This file is part of Tree.
  *
  * (c) 2013 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;
 
 /**
- * Visitor interface for Nodes
+ * Visitor interface for Nodes.
  *
- * @package    Tree
  * @author     Nicolò Martini <nicmartnic@gmail.com>
  */
 interface Visitor
 {
     /**
      * @param NodeInterface $node
+     *
      * @return mixed
      */
     public function visit(NodeInterface $node);

--- a/src/Visitor/YieldVisitor.php
+++ b/src/Visitor/YieldVisitor.php
@@ -13,14 +13,8 @@ namespace Tree\Visitor;
 
 use Tree\Node\NodeInterface;
 
-/**
- * Class YieldVisitor.
- */
 class YieldVisitor implements Visitor
 {
-    /**
-     * {@inheritdoc}
-     */
     public function visit(NodeInterface $node)
     {
         if ($node->isLeaf()) {

--- a/src/Visitor/YieldVisitor.php
+++ b/src/Visitor/YieldVisitor.php
@@ -1,22 +1,20 @@
 <?php
-/**
- * This file is part of Tree
+
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @author Nicolò Martini <nicmartnic@gmail.com>
  */
 
 namespace Tree\Visitor;
 
-
 use Tree\Node\NodeInterface;
 
 /**
- * Class YieldVisitor
- *
- * @package Tree\Visitor
+ * Class YieldVisitor.
  */
 class YieldVisitor implements Visitor
 {
@@ -32,9 +30,9 @@ class YieldVisitor implements Visitor
         $yield = [];
 
         foreach ($node->getChildren() as $child) {
-            $yield = array_merge($yield, $child->accept($this));
+            $yield = \array_merge($yield, $child->accept($this));
         }
 
         return $yield;
     }
-} 
+}

--- a/tests/Builder/NodeBuilderTest.php
+++ b/tests/Builder/NodeBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
@@ -7,46 +8,52 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Test\Builder;
 
 use PHPUnit\Framework;
-use Tree\Node\Node;
 use Tree\Builder\NodeBuilder;
+use Tree\Node\Node;
 
 /**
- * Unit tests for class FirstClass
+ * Unit tests for class FirstClass.
+ *
+ * @internal
+ * @coversNothing
  */
-class NodeTest extends Framework\TestCase
+final class NodeBuilderTest extends Framework\TestCase
 {
-    /** @var NodeBuilder */
+    /**
+     * @var NodeBuilder
+     */
     protected $builder;
 
-    public function setUp()
+    protected function setUp()
     {
-        $this->builder = new NodeBuilder;
+        $this->builder = new NodeBuilder();
     }
 
     public function testConstructorCreatesEmptyNodeIfNoSpecified()
     {
-        $builder = new NodeBuilder;
+        $builder = new NodeBuilder();
 
-        $this->assertNull($builder->getNode()->getValue());
+        self::assertNull($builder->getNode()->getValue());
     }
 
     public function testConstructor()
     {
         $builder = new NodeBuilder($node = new Node('node'));
 
-        $this->assertSame($node, $builder->getNode());
+        self::assertSame($node, $builder->getNode());
     }
 
     public function testSetNodeAndGetNode()
     {
         $this->builder->setNode($node1 = new Node('node1'));
-        $this->assertSame($node1, $this->builder->getNode());
+        self::assertSame($node1, $this->builder->getNode());
 
         $this->builder->setNode($node2 = new Node('node2'));
-        $this->assertSame($node2, $this->builder->getNode());
+        self::assertSame($node2, $this->builder->getNode());
     }
 
     public function testLeaf()
@@ -55,8 +62,8 @@ class NodeTest extends Framework\TestCase
 
         $children = $this->builder->getNode()->getChildren();
 
-        $this->assertSame('a', $children[0]->getValue());
-        $this->assertSame('b', $children[1]->getValue());
+        self::assertSame('a', $children[0]->getValue());
+        self::assertSame('b', $children[1]->getValue());
     }
 
     public function testLeafs()
@@ -65,8 +72,8 @@ class NodeTest extends Framework\TestCase
 
         $children = $this->builder->getNode()->getChildren();
 
-        $this->assertSame('a', $children[0]->getValue());
-        $this->assertSame('b', $children[1]->getValue());
+        self::assertSame('a', $children[0]->getValue());
+        self::assertSame('b', $children[1]->getValue());
     }
 
     public function testTreeAddNewNodeAsChildOfTheParentNode()
@@ -74,23 +81,22 @@ class NodeTest extends Framework\TestCase
         $this->builder
             ->value('root')
             ->tree('a')
-                ->tree('b')->end()
-                ->leaf('c')
-            ->end()
-        ;
+            ->tree('b')->end()
+            ->leaf('c')
+            ->end();
 
         $node = $this->builder->getNode();
-        $this->assertSame(array('a'), $this->childrenValues($node->getChildren()));
+        self::assertSame(['a'], $this->childrenValues($node->getChildren()));
 
         $subtree = $node->getChildren()[0];
-        $this->assertSame(array('b', 'c'), $this->childrenValues($subtree->getChildren()));
+        self::assertSame(['b', 'c'], $this->childrenValues($subtree->getChildren()));
     }
 
     public function testTree()
     {
         $this->builder->tree('a')->tree('b');
 
-        $this->assertSame('b', $this->builder->getNode()->getValue());
+        self::assertSame('b', $this->builder->getNode()->getValue());
     }
 
     public function testEnd()
@@ -98,41 +104,42 @@ class NodeTest extends Framework\TestCase
         $this->builder
             ->value('root')
             ->tree('a')
-                ->tree('b')
-                    ->tree('c')
-                    ->end();
+            ->tree('b')
+            ->tree('c')
+            ->end();
 
-        $this->assertSame('b', $this->builder->getNode()->getValue());
-
-        $this->builder->end();
-        $this->assertSame('a', $this->builder->getNode()->getValue());
+        self::assertSame('b', $this->builder->getNode()->getValue());
 
         $this->builder->end();
-        $this->assertSame('root', $this->builder->getNode()->getValue());
+        self::assertSame('a', $this->builder->getNode()->getValue());
+
+        $this->builder->end();
+        self::assertSame('root', $this->builder->getNode()->getValue());
     }
 
     public function testValue()
     {
         $this->builder->value('foo')->value('bar');
 
-        $this->assertSame('bar', $this->builder->getNode()->getValue());
+        self::assertSame('bar', $this->builder->getNode()->getValue());
     }
 
     public function testNodeInstanceByValue()
     {
         $node = $this->builder->nodeInstanceByValue('baz');
 
-        $this->assertSame('baz', $node->getValue());
-        $this->assertInstanceOf('Tree\Node\Node', $node);
+        self::assertSame('baz', $node->getValue());
+        self::assertInstanceOf('Tree\Node\Node', $node);
     }
 
     /**
      * @param array[Node] $children
+     *
      * @return array
      */
     private function childrenValues(array $children)
     {
-        return array_map(function(Node $node) {
+        return \array_map(static function (Node $node) {
             return $node->getValue();
         }, $children);
     }

--- a/tests/Builder/NodeBuilderTest.php
+++ b/tests/Builder/NodeBuilderTest.php
@@ -16,8 +16,6 @@ use Tree\Builder\NodeBuilder;
 use Tree\Node\Node;
 
 /**
- * Unit tests for class FirstClass.
- *
  * @internal
  *
  * @covers \Tree\Builder\NodeBuilder

--- a/tests/Builder/NodeBuilderTest.php
+++ b/tests/Builder/NodeBuilderTest.php
@@ -19,7 +19,8 @@ use Tree\Node\Node;
  * Unit tests for class FirstClass.
  *
  * @internal
- * @coversNothing
+ *
+ * @covers \Tree\Builder\NodeBuilder
  */
 final class NodeBuilderTest extends Framework\TestCase
 {

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -18,7 +18,8 @@ use Tree\Node\Node;
  * Unit tests for class FirstClass.
  *
  * @internal
- * @coversNothing
+ *
+ * @covers \Tree\Node\Node
  */
 final class NodeTest extends Framework\TestCase
 {

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Tree.
  *
@@ -7,133 +8,130 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Tree\Test\Tree;
 
 use PHPUnit\Framework;
 use Tree\Node\Node;
 
 /**
- * Unit tests for class FirstClass
+ * Unit tests for class FirstClass.
+ *
+ * @internal
+ * @coversNothing
  */
-class NodeTest extends Framework\TestCase
+final class NodeTest extends Framework\TestCase
 {
     public function testSetValue()
     {
-        $node = new Node;
+        $node = new Node();
 
         $node->setValue('string value');
 
-        $this->assertSame('string value', $node->getValue());
+        self::assertSame('string value', $node->getValue());
 
         $node->setValue($object = new \stdClass());
         $object->foo = 'bar';
 
-        $this->assertSame($object, $node->getValue());
+        self::assertSame($object, $node->getValue());
     }
 
     public function testAddAndGetChildren()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
             ->addChild($child2 = new Node('child2'))
-            ->addChild($child3 = new Node('child3'))
-        ;
+            ->addChild($child3 = new Node('child3'));
 
-        $this->assertSame([$child1, $child2, $child3], $root->getChildren());
+        self::assertSame([$child1, $child2, $child3], $root->getChildren());
     }
 
     public function testAddChildSetParent()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
-            ->addChild($child2 = new Node('child2'))
-        ;
+            ->addChild($child2 = new Node('child2'));
 
-        $this->assertSame($root, $child1->getParent());
-        $this->assertSame($root, $child2->getParent());
+        self::assertSame($root, $child1->getParent());
+        self::assertSame($root, $child2->getParent());
     }
 
     public function testSetAndGetParent()
     {
-        $root = new Node;
+        $root = new Node();
         $child = new Node('foo');
 
         $child->setParent($root);
 
-        $this->assertSame($root, $child->getParent());
+        self::assertSame($root, $child->getParent());
     }
 
     public function testSetChildren()
     {
         $children = [new Node('child1'), new Node('child2'), new Node('child3')];
 
-        $root = new Node;
+        $root = new Node();
 
         $root->setChildren($children);
 
-        $this->assertSame($children, $root->getChildren());
+        self::assertSame($children, $root->getChildren());
     }
 
     public function testSetChildrenSetParentsReferences()
-     {
-         $root = new Node;
-         $root
-             ->addChild($child1 = new Node('child1'))
-             ->addChild($child2 = new Node('child2'))
-         ;
+    {
+        $root = new Node();
+        $root
+            ->addChild($child1 = new Node('child1'))
+            ->addChild($child2 = new Node('child2'));
 
-         $this->assertSame($root, $child1->getParent());
-         $this->assertSame($root, $child2->getParent());
-     }
+        self::assertSame($root, $child1->getParent());
+        self::assertSame($root, $child2->getParent());
+    }
 
     public function testRemoveChild()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
             ->addChild($child2 = new Node('child2'))
             ->addChild($child3 = new Node('child3'))
-            ->removeChild($child2)
-        ;
+            ->removeChild($child2);
 
-        $this->assertSame([$child1, $child3], $root->getChildren());
+        self::assertSame([$child1, $child3], $root->getChildren());
     }
 
     public function testRemoveChildRemoveParentReference()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
-            ->removeChild($child1)
-        ;
+            ->removeChild($child1);
 
-        $this->assertNull($child1->getParent());
+        self::assertNull($child1->getParent());
     }
 
     public function testRemoveAllChildrenRemoveParentReferences()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
-            ->removeAllChildren()
-        ;
+            ->removeAllChildren();
 
-        $this->assertNull($child1->getParent());
+        self::assertNull($child1->getParent());
     }
 
     public function testRemoveAllChildren()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
             ->addChild($child2 = new Node('child2'))
             ->addChild($child3 = new Node('child3'))
-            ->removeAllChildren()
-        ;
+            ->removeAllChildren();
 
-        $this->assertEmpty($root->getChildren());
+        self::assertEmpty($root->getChildren());
     }
 
     public function testGetAncestors()
@@ -143,7 +141,7 @@ class NodeTest extends Framework\TestCase
         $a->addChild($b = new Node('b'));
         $b->addChild($c = new Node('c'));
 
-        $this->assertSame([$root, $a, $b], $c->getAncestors());
+        self::assertSame([$root, $a, $b], $c->getAncestors());
     }
 
     public function testGetAncestorsAndSelf()
@@ -152,7 +150,7 @@ class NodeTest extends Framework\TestCase
         $root->addChild($a = new Node('a'));
         $a->addChild($b = new Node('b'));
 
-        $this->assertSame([$root, $a, $b], $b->getAncestorsAndSelf());
+        self::assertSame([$root, $a, $b], $b->getAncestorsAndSelf());
     }
 
     public function testGetNeighbors()
@@ -163,7 +161,7 @@ class NodeTest extends Framework\TestCase
             ->addChild($b = new Node('b'))
             ->addChild($c = new Node('c'));
 
-        $this->assertSame([$b, $c], $a->getNeighbors());
+        self::assertSame([$b, $c], $a->getNeighbors());
     }
 
     public function testGetNeighborsAndSelf()
@@ -174,18 +172,18 @@ class NodeTest extends Framework\TestCase
             ->addChild($b = new Node('b'))
             ->addChild($c = new Node('c'));
 
-        $this->assertSame([$a, $b, $c], $a->getNeighborsAndSelf());
+        self::assertSame([$a, $b, $c], $a->getNeighborsAndSelf());
     }
 
     public function testIsLeaf()
     {
-        $root = new Node;
+        $root = new Node();
 
-        $this->assertTrue($root->isLeaf());
+        self::assertTrue($root->isLeaf());
 
         $root->addChild(new Node('child'));
 
-        $this->assertFalse($root->isLeaf());
+        self::assertFalse($root->isLeaf());
     }
 
     public function testRoot()
@@ -195,7 +193,7 @@ class NodeTest extends Framework\TestCase
                 (new Node('child'))->addChild($grandchild = new Node('grandchild'))
             );
 
-        $this->assertSame($root, $grandchild->root());
+        self::assertSame($root, $grandchild->root());
     }
 
     public function testIsRoot()
@@ -203,8 +201,8 @@ class NodeTest extends Framework\TestCase
         $root = new Node('root');
         $root->addChild($child = new Node('child'));
 
-        $this->assertTrue($root->isRoot());
-        $this->assertFalse($child->isRoot());
+        self::assertTrue($root->isRoot());
+        self::assertFalse($child->isRoot());
     }
 
     public function testIsChild()
@@ -212,73 +210,65 @@ class NodeTest extends Framework\TestCase
         $root = new Node('root');
         $root->addChild($child = new Node('child'));
 
-        $this->assertTrue($child->isChild());
-        $this->assertFalse($root->isChild());
+        self::assertTrue($child->isChild());
+        self::assertFalse($root->isChild());
     }
 
     public function testGetDepth()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
             ->addChild($child2 = new Node('child2'))
-            ->addChild($child3 = new Node('child3'))
-        ;
+            ->addChild($child3 = new Node('child3'));
 
         $child3
-            ->addChild($child4 = new Node("a"))
-            ->addChild(new Node("b"))
-        ;
+            ->addChild($child4 = new Node('a'))
+            ->addChild(new Node('b'));
 
-        $this->assertSame(1, $child1->getDepth());
-        $this->assertSame(0, $root->getDepth());
-        $this->assertSame(2, $child4->getDepth());
+        self::assertSame(1, $child1->getDepth());
+        self::assertSame(0, $root->getDepth());
+        self::assertSame(2, $child4->getDepth());
     }
 
     public function testGetHeight()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
             ->addChild($child2 = new Node('child2'))
-            ->addChild($child3 = new Node('child3'))
-        ;
+            ->addChild($child3 = new Node('child3'));
 
         $child3
-            ->addChild(new Node("a"))
-            ->addChild(new Node("b"))
-        ;
+            ->addChild(new Node('a'))
+            ->addChild(new Node('b'));
 
-        $this->assertSame(0, $child1->getHeight());
-        $this->assertSame(2, $root->getHeight());
-        $this->assertSame(1, $child3->getHeight());
+        self::assertSame(0, $child1->getHeight());
+        self::assertSame(2, $root->getHeight());
+        self::assertSame(1, $child3->getHeight());
     }
-
 
     public function testGetSize()
     {
-        $root = new Node;
+        $root = new Node();
         $root
             ->addChild($child1 = new Node('child1'))
             ->addChild($child2 = new Node('child2'))
-            ->addChild($child3 = new Node('child3'))
-        ;
+            ->addChild($child3 = new Node('child3'));
 
         $child3
-            ->addChild(new Node("a"))
-            ->addChild($child4 = new Node("b"))
-        ;
+            ->addChild(new Node('a'))
+            ->addChild($child4 = new Node('b'));
 
-        $child4->addChild($child5 = new Node("c"));
+        $child4->addChild($child5 = new Node('c'));
         $child5
-            ->addChild(new Node("d"))
-            ->addChild(new Node("f"))
-        ;
+            ->addChild(new Node('d'))
+            ->addChild(new Node('f'));
 
-        $this->assertSame(9, $root->getSize());
-        $this->assertSame(3, $child5->getSize());
-        $this->assertSame(4, $child4->getSize());
-        $this->assertSame(6, $child3->getSize());
-        $this->assertSame(1, $child2->getSize());
+        self::assertSame(9, $root->getSize());
+        self::assertSame(3, $child5->getSize());
+        self::assertSame(4, $child4->getSize());
+        self::assertSame(6, $child3->getSize());
+        self::assertSame(1, $child2->getSize());
     }
 }

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -15,8 +15,6 @@ use PHPUnit\Framework;
 use Tree\Node\Node;
 
 /**
- * Unit tests for class FirstClass.
- *
  * @internal
  *
  * @covers \Tree\Node\Node

--- a/tests/Visitor/PostOrderVisitorTest.php
+++ b/tests/Visitor/PostOrderVisitorTest.php
@@ -17,7 +17,8 @@ use Tree\Visitor\PostOrderVisitor;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Tree\Visitor\PostOrderVisitor
  */
 final class PostOrderVisitorTest extends Framework\TestCase
 {

--- a/tests/Visitor/PostOrderVisitorTest.php
+++ b/tests/Visitor/PostOrderVisitorTest.php
@@ -1,22 +1,35 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Test\Visitor;
 
 use PHPUnit\Framework;
 use Tree\Node\Node;
 use Tree\Visitor\PostOrderVisitor;
 
-class PostOrderVisitorTest extends Framework\TestCase
+/**
+ * @internal
+ * @coversNothing
+ */
+final class PostOrderVisitorTest extends Framework\TestCase
 {
     public function testImplementsInterface()
     {
         $visitor = new PostOrderVisitor();
 
-        $this->assertInstanceOf('Tree\Visitor\Visitor', $visitor);
+        self::assertInstanceOf('Tree\Visitor\Visitor', $visitor);
     }
 
     /**
-     * root
+     * root.
      */
     public function testWalkTreeWithOneNode()
     {
@@ -28,13 +41,13 @@ class PostOrderVisitorTest extends Framework\TestCase
             $root,
         ];
 
-        $this->assertSame($expected, $visitor->visit($root));
+        self::assertSame($expected, $visitor->visit($root));
     }
 
     /**
      * root
      *  |
-     *  a
+     *  a.
      */
     public function testWalkTreeWithTwoNodes()
     {
@@ -51,7 +64,7 @@ class PostOrderVisitorTest extends Framework\TestCase
             $root,
         ];
 
-        $this->assertSame($expected, $visitor->visit($root));
+        self::assertSame($expected, $visitor->visit($root));
     }
 
     /**
@@ -59,7 +72,7 @@ class PostOrderVisitorTest extends Framework\TestCase
      *    /|\
      *   a b c
      *  /| |
-     * d e f
+     * d e f.
      */
     public function testWalkTreeWithMoreNodes()
     {
@@ -93,7 +106,7 @@ class PostOrderVisitorTest extends Framework\TestCase
             $root,
         ];
 
-        $this->assertSame($expected, $visitor->visit($root));
+        self::assertSame($expected, $visitor->visit($root));
     }
 
     /**
@@ -101,7 +114,7 @@ class PostOrderVisitorTest extends Framework\TestCase
      *    /|\
      *   a b c
      *  /| |
-     * d e f
+     * d e f.
      */
     public function testWalkSubTree()
     {
@@ -131,6 +144,6 @@ class PostOrderVisitorTest extends Framework\TestCase
             $a,
         ];
 
-        $this->assertSame($expected, $visitor->visit($a));
+        self::assertSame($expected, $visitor->visit($a));
     }
 }

--- a/tests/Visitor/PreOrderVisitorTest.php
+++ b/tests/Visitor/PreOrderVisitorTest.php
@@ -1,22 +1,35 @@
 <?php
 
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tree\Test\Visitor;
 
 use PHPUnit\Framework;
 use Tree\Node\Node;
 use Tree\Visitor\PreOrderVisitor;
 
-class PreOrderVisitorTest extends Framework\TestCase
+/**
+ * @internal
+ * @coversNothing
+ */
+final class PreOrderVisitorTest extends Framework\TestCase
 {
     public function testImplementsInterface()
     {
         $visitor = new PreOrderVisitor();
 
-        $this->assertInstanceOf('Tree\Visitor\Visitor', $visitor);
+        self::assertInstanceOf('Tree\Visitor\Visitor', $visitor);
     }
 
     /**
-     * root
+     * root.
      */
     public function testWalkTreeWithOneNode()
     {
@@ -28,13 +41,13 @@ class PreOrderVisitorTest extends Framework\TestCase
             $root,
         ];
 
-        $this->assertSame($expected, $visitor->visit($root));
+        self::assertSame($expected, $visitor->visit($root));
     }
 
     /**
      * root
      *  |
-     *  a
+     *  a.
      */
     public function testWalkTreeWithTwoNodes()
     {
@@ -51,7 +64,7 @@ class PreOrderVisitorTest extends Framework\TestCase
             $a,
         ];
 
-        $this->assertSame($expected, $visitor->visit($root));
+        self::assertSame($expected, $visitor->visit($root));
     }
 
     /**
@@ -59,7 +72,7 @@ class PreOrderVisitorTest extends Framework\TestCase
      *    /|\
      *   a b c
      *  /| |
-     * d e f
+     * d e f.
      */
     public function testWalkTreeWithMoreNodes()
     {
@@ -93,7 +106,7 @@ class PreOrderVisitorTest extends Framework\TestCase
             $c,
         ];
 
-        $this->assertSame($expected, $visitor->visit($root));
+        self::assertSame($expected, $visitor->visit($root));
     }
 
     /**
@@ -101,7 +114,7 @@ class PreOrderVisitorTest extends Framework\TestCase
      *    /|\
      *   a b c
      *  /| |
-     * d e f
+     * d e f.
      */
     public function testWalkSubTree()
     {
@@ -131,6 +144,6 @@ class PreOrderVisitorTest extends Framework\TestCase
             $e,
         ];
 
-        $this->assertSame($expected, $visitor->visit($a));
+        self::assertSame($expected, $visitor->visit($a));
     }
 }

--- a/tests/Visitor/PreOrderVisitorTest.php
+++ b/tests/Visitor/PreOrderVisitorTest.php
@@ -17,7 +17,8 @@ use Tree\Visitor\PreOrderVisitor;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Tree\Visitor\PreOrderVisitor
  */
 final class PreOrderVisitorTest extends Framework\TestCase
 {

--- a/tests/Visitor/YieldVisitorTest.php
+++ b/tests/Visitor/YieldVisitorTest.php
@@ -1,11 +1,12 @@
 <?php
-/**
- * This file is part of Tree
+
+/*
+ * This file is part of Tree.
+ *
+ * (c) 2013 Nicolò Martini
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @author Nicolò Martini <nicmartnic@gmail.com>
  */
 
 namespace Tree\Test\Visitor;
@@ -14,7 +15,11 @@ use PHPUnit\Framework;
 use Tree\Node\Node;
 use Tree\Visitor\YieldVisitor;
 
-class YieldVisitorTest extends Framework\TestCase
+/**
+ * @internal
+ * @coversNothing
+ */
+final class YieldVisitorTest extends Framework\TestCase
 {
     /**
      *              root
@@ -23,7 +28,7 @@ class YieldVisitorTest extends Framework\TestCase
      *            / \
      *           C   D
      *               |
-     *               E
+     *               E.
      */
     public function testGetYield()
     {
@@ -40,14 +45,14 @@ class YieldVisitorTest extends Framework\TestCase
 
         $yield = $root->accept($visitor);
 
-        $this->assertSame([$c, $e, $b], $yield);
+        self::assertSame([$c, $e, $b], $yield);
     }
 
     public function testTheYieldOfALeafNodeIsTheNodeItself()
     {
         $node = new Node('node');
-        $visitor = new YieldVisitor;
+        $visitor = new YieldVisitor();
 
-        $this->assertSame([$node], $node->accept($visitor));
+        self::assertSame([$node], $node->accept($visitor));
     }
 }

--- a/tests/Visitor/YieldVisitorTest.php
+++ b/tests/Visitor/YieldVisitorTest.php
@@ -17,7 +17,8 @@ use Tree\Visitor\YieldVisitor;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Tree\Visitor\YieldVisitor
  */
 final class YieldVisitorTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] requires `ergebnis/php-cs-fixer-config`
* [x] adds a configuration for `friendsofphp/php-cs-fixer`
* [x] runs `php-cs-fixer` on GitHub Actions
* [x] runs `php-cs-fixer` in the `coding-standards` target of `Makefile`
* [x] runs `php-cs-fixer`
* [x] adjusts `@covers` annotations
* [x] removes useless DocBlocks
* [x] manually fixes a few DocBlocks