### PR TITLE
Fix NodeTest class namespace and PHPUnit fixture

### DIFF
--- a/tests/Builder/NodeBuilderTest.php
+++ b/tests/Builder/NodeBuilderTest.php
@@ -27,7 +27,7 @@ final class NodeBuilderTest extends Framework\TestCase
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new NodeBuilder();
     }

--- a/tests/Node/NodeTest.php
+++ b/tests/Node/NodeTest.php
@@ -9,7 +9,7 @@
  * @see https://github.com/nicmart/Tree
  */
 
-namespace Tree\Test\Tree;
+namespace Tree\Test\Node;
 
 use PHPUnit\Framework;
 use Tree\Node\Node;


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` method.
- Fixing the `NodeTest` class namespace to be compatible with `PSR-4` autoloading.