### PR TITLE
Fix: Add `getSize()` to `NodeInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.5.0...master`][0.5.0...master].
 
+### Changed
+
+- Added `getSize()` to `NodeInterface` ([#147]), by [@localheinz]
+
 ## [`0.5.0`][0.5.0]
 
 For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
@@ -200,6 +204,7 @@ For a full diff see [`fcfd14e...v0.1.1`][fcfd14e...0.1.1].
 [#136]: https://github.com/nicmart/Tree/pull/136
 [#137]: https://github.com/nicmart/Tree/pull/137
 [#138]: https://github.com/nicmart/Tree/pull/138
+[#147]: https://github.com/nicmart/Tree/pull/147
 
 [@asalazar-pley]: https://github.com/asalazar-pley
 [@Djuki]: https://github.com/Djuki

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -52,11 +52,7 @@
     </MixedArgument>
     <MixedAssignment>
       <code>$child</code>
-      <code>$size</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code>int</code>
-    </MixedInferredReturnType>
     <MixedReturnTypeCoercion>
       <code>getAncestorsAndSelf</code>
     </MixedReturnTypeCoercion>
@@ -65,9 +61,6 @@
       <code>getChildren</code>
       <code>getDepth</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod>
-      <code>getSize</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Visitor/PostOrderVisitor.php">
     <MixedArgument>

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -151,6 +151,13 @@ interface NodeInterface
     public function getHeight();
 
     /**
+     * Return the number of nodes in a tree.
+     *
+     * @return int
+     */
+    public function getSize();
+
+    /**
      * Accept method for the visitor pattern (see http://en.wikipedia.org/wiki/Visitor_pattern).
      */
     public function accept(Visitor $visitor);

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -203,11 +203,6 @@ trait NodeTrait
         return \max($heights) + 1;
     }
 
-    /**
-     * Return the number of nodes in a tree.
-     *
-     * @return int
-     */
     public function getSize()
     {
         $size = 1;


### PR DESCRIPTION
This pull request

- [x] adds `getSize()` to `NodeInterface`