### PR TITLE
Fix: Add `root()` to `NodeInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`0.5.0...master`][0.5.0...master].
 ### Changed
 
 - Added `getSize()` to `NodeInterface` ([#147]), by [@localheinz]
+- Added `root()` to `NodeInterface` ([#148]), by [@localheinz]
 
 ## [`0.5.0`][0.5.0]
 
@@ -205,6 +206,7 @@ For a full diff see [`fcfd14e...v0.1.1`][fcfd14e...0.1.1].
 [#137]: https://github.com/nicmart/Tree/pull/137
 [#138]: https://github.com/nicmart/Tree/pull/138
 [#147]: https://github.com/nicmart/Tree/pull/147
+[#148]: https://github.com/nicmart/Tree/pull/148
 
 [@asalazar-pley]: https://github.com/asalazar-pley
 [@Djuki]: https://github.com/Djuki

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -137,6 +137,13 @@ interface NodeInterface
     public function isLeaf();
 
     /**
+     * Find the root of the node.
+     *
+     * @return NodeInterface
+     */
+    public function root();
+
+    /**
      * Return the distance from the current node to the root.
      *
      * @return int

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -151,11 +151,6 @@ trait NodeTrait
         return 0 === \count($this->children);
     }
 
-    /**
-     * Find the root of the node.
-     *
-     * @return NodeInterface
-     */
     public function root()
     {
         $node = $this;


### PR DESCRIPTION
This pull request

- [x] adds `root()` to `NodeInterface`