### PR TITLE
Fix: Return empty `array` from `getNeighbors()` when node is root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`0.6.0...master`][0.6.0...master].
 - Added a missing return type declaration to `NodeInterface::getSize()` ([#150]), by [@localheinz]
 - Added parameter type declarations ([#151]), by [@localheinz]
 - Added property type declarations ([#152]), by [@localheinz]
+- Returned empty array from `Node::getNeigbors()` when node is root ([#153]), by [@localheinz]
 
 ## [`0.6.0`][0.6.0]
 
@@ -226,6 +227,7 @@ For a full diff see [`fcfd14e...v0.1.1`][fcfd14e...0.1.1].
 [#150]: https://github.com/nicmart/Tree/pull/150
 [#151]: https://github.com/nicmart/Tree/pull/151
 [#152]: https://github.com/nicmart/Tree/pull/152
+[#153]: https://github.com/nicmart/Tree/pull/153
 
 [@asalazar-pley]: https://github.com/asalazar-pley
 [@Djuki]: https://github.com/Djuki

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -115,6 +115,10 @@ trait NodeTrait
 
     public function getNeighbors(): array
     {
+        if (null === $this->parent) {
+            return [];
+        }
+
         $neighbors = $this->getParent()->getChildren();
         $current = $this;
 

--- a/test/Unit/Node/NodeTest.php
+++ b/test/Unit/Node/NodeTest.php
@@ -198,6 +198,13 @@ final class NodeTest extends Framework\TestCase
         self::assertSame([$root, $a, $b], $b->getAncestorsAndSelf());
     }
 
+    public function testGetNeighborsReturnsEmptyArrayWhenNodeDoesNotHaveParent(): void
+    {
+        $node = new Node(self::faker()->sentence());
+
+        self::assertSame([], $node->getNeighbors());
+    }
+
     public function testGetNeighbors(): void
     {
         $root = new Node('r');


### PR DESCRIPTION

This pull request

- [x] asserts that `getNeighbors()` returns an empty `array` when a node is the root of a tree
- [x] returns an empty array from `getNeighbors()` when a node is the root of a tree