### PR TITLE
Fix: Return array with node from `getNeighborsAndSelf()` when node is root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`0.6.0...master`][0.6.0...master].
 - Added parameter type declarations ([#151]), by [@localheinz]
 - Added property type declarations ([#152]), by [@localheinz]
 - Returned empty array from `Node::getNeigbors()` when node is root ([#153]), by [@localheinz]
+- Returned array with node only from `Node::getNeigborsAndSelf()` when node is root ([#154]), by [@localheinz]
 
 ## [`0.6.0`][0.6.0]
 
@@ -228,6 +229,7 @@ For a full diff see [`fcfd14e...v0.1.1`][fcfd14e...0.1.1].
 [#151]: https://github.com/nicmart/Tree/pull/151
 [#152]: https://github.com/nicmart/Tree/pull/152
 [#153]: https://github.com/nicmart/Tree/pull/153
+[#154]: https://github.com/nicmart/Tree/pull/154
 
 [@asalazar-pley]: https://github.com/asalazar-pley
 [@Djuki]: https://github.com/Djuki

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -129,6 +129,12 @@ trait NodeTrait
 
     public function getNeighborsAndSelf(): array
     {
+        if (null === $this->parent) {
+            return [
+                $this,
+            ];
+        }
+
         return $this->getParent()->getChildren();
     }
 

--- a/test/Unit/Node/NodeTest.php
+++ b/test/Unit/Node/NodeTest.php
@@ -216,6 +216,17 @@ final class NodeTest extends Framework\TestCase
         self::assertSame([$b, $c], $a->getNeighbors());
     }
 
+    public function testGetNeighborsAndSelfReturnsArrayWithNodeWhenNodeDoesNotHaveParent(): void
+    {
+        $node = new Node(self::faker()->sentence());
+
+        $expected = [
+            $node,
+        ];
+
+        self::assertSame($expected, $node->getNeighborsAndSelf());
+    }
+
     public function testGetNeighborsAndSelf(): void
     {
         $root = new Node('r');


### PR DESCRIPTION
This pull request

- [x] asserts that `getNeighborsAndSelf()` returns an `array` with the node only when a node is the root of a tree
- [x] returns an array with the node only from `getNeighborsAndSelf()` when a node is the root of a tree