### PR TITLE
Fix: Throw `LogicException` when attempting to get `Node` from empty `NodeBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.7.1...master`][0.7.1...master].
 
+### Fixed
+
+- Started throwing a `LogicException` when attempting to get a `Node` from an empty `NodeBuilder` ([#209]), by [@localheinz]
+
 ## [`0.7.1`][0.7.1]
 
 For a full diff see [0.7.0...0.7.1`][0.7.0...0.7.1].
@@ -250,6 +254,7 @@ For a full diff see [`fcfd14e...v0.1.1`][fcfd14e...0.1.1].
 [#153]: https://github.com/nicmart/Tree/pull/153
 [#154]: https://github.com/nicmart/Tree/pull/154
 [#168]: https://github.com/nicmart/Tree/pull/168
+[#209]: https://github.com/nicmart/Tree/pull/209
 
 [@asalazar-pley]: https://github.com/asalazar-pley
 [@Djuki]: https://github.com/Djuki

--- a/src/Builder/NodeBuilder.php
+++ b/src/Builder/NodeBuilder.php
@@ -40,7 +40,13 @@ class NodeBuilder implements NodeBuilderInterface
 
     public function getNode(): NodeInterface
     {
-        return $this->nodeStack[\count($this->nodeStack) - 1];
+        $count = \count($this->nodeStack);
+
+        if (0 === $count) {
+            throw new \LogicException('The node builder currently does not manage any nodes.');
+        }
+
+        return $this->nodeStack[$count - 1];
     }
 
     public function leaf(mixed $value = null): static

--- a/src/Builder/NodeBuilderInterface.php
+++ b/src/Builder/NodeBuilderInterface.php
@@ -27,6 +27,8 @@ interface NodeBuilderInterface
 
     /**
      * Get the node the builder manages.
+     *
+     * @throws \LogicException
      */
     public function getNode(): NodeInterface;
 

--- a/test/Unit/Builder/NodeBuilderTest.php
+++ b/test/Unit/Builder/NodeBuilderTest.php
@@ -47,6 +47,18 @@ final class NodeBuilderTest extends Framework\TestCase
         self::assertSame($node2, $builder->getNode());
     }
 
+    public function testGetNodeThrowsLogicExceptionWhenNodeBuilderDoesNotManageAnyNodes(): void
+    {
+        $builder = new NodeBuilder();
+
+        $builder->end();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The node builder currently does not manage any nodes.');
+
+        $builder->getNode();
+    }
+
     public function testLeaf(): void
     {
         $builder = new NodeBuilder();


### PR DESCRIPTION
This pull request

- [x] asserts that `NodeBuilder::getNode()` throws LogicException when `NodeBuider` does not manage any nodes
- [x] throws a `LogicException` when attempting to get a `Node` from an empty `NodeBuilder`

Fixes #208.