### PR TITLE
Fix typo in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 /.github/                       export-ignore
 /.phive/                        export-ignore
-/tests/                         export-ignore
+/test/                          export-ignore
 /.editorconfig                  export-ignore
 /.gitattributes                 export-ignore
 /.gitignore                     export-ignore


### PR DESCRIPTION
Hi @localheinz,
there is a small typo in the gitattribute file.

The test folder is `test` and not `tests`.