### PR TITLE
use generic for node value

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -30,6 +30,7 @@ $ruleSet = PhpCsFixer\Config\RuleSet\Php80::create()
         'declare_strict_types' => false,
         'final_class' => false,
         'void_return' => false,
+        'phpdoc_to_property_type' => false, // when turned on it breaks generics phpdoc types
     ]));
 
 $config = PhpCsFixer\Config\Factory::fromRuleSet($ruleSet);

--- a/composer.lock
+++ b/composer.lock
@@ -1557,16 +1557,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.56.1",
+            "version": "v3.56.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "69c6168ae8bc96dc656c7f6c7271120a68ae5903"
+                "reference": "e8c12f9501f6b66caf9072404f960b6af5672b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/69c6168ae8bc96dc656c7f6c7271120a68ae5903",
-                "reference": "69c6168ae8bc96dc656c7f6c7271120a68ae5903",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/e8c12f9501f6b66caf9072404f960b6af5672b2e",
+                "reference": "e8c12f9501f6b66caf9072404f960b6af5672b2e",
                 "shasum": ""
             },
             "require": {
@@ -1638,7 +1638,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.56.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.56.2"
             },
             "funding": [
                 {
@@ -1646,7 +1646,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-05-10T11:31:15+00:00"
+            "time": "2024-05-15T14:37:10+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -6136,13 +6136,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.0.25"
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,62 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="src/Builder/NodeBuilder.php">
     <MixedAssignment>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
   </file>
   <file src="src/Builder/NodeBuilderInterface.php">
     <PossiblyUnusedReturnValue>
-      <code>static</code>
-      <code>static</code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Node/NodeInterface.php">
     <PossiblyUnusedReturnValue>
-      <code>mixed</code>
-      <code>static</code>
-      <code>static</code>
-      <code>static</code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
+      <code><![CDATA[static]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Node/NodeTrait.php">
     <ArgumentTypeCoercion>
-      <code>$heights</code>
+      <code><![CDATA[$heights]]></code>
     </ArgumentTypeCoercion>
     <LessSpecificImplementedReturnType>
-      <code>array</code>
-      <code>array</code>
-      <code>array</code>
+      <code><![CDATA[array]]></code>
+      <code><![CDATA[array]]></code>
+      <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
     <MixedArgument>
-      <code>$child</code>
+      <code><![CDATA[$child]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$child</code>
-      <code>$child</code>
-      <code>$child</code>
-      <code>$child</code>
-      <code>$heights[]</code>
-      <code>$size</code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$heights[]]]></code>
+      <code><![CDATA[$size]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>int</code>
-      <code>int</code>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[int]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
-      <code>getHeight</code>
-      <code>getSize</code>
-      <code>setParent</code>
+      <code><![CDATA[getHeight]]></code>
+      <code><![CDATA[getSize]]></code>
+      <code><![CDATA[setParent]]></code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$child->getSize()]]></code>
-      <code>\max($heights)</code>
+      <code><![CDATA[\max($heights)]]></code>
     </MixedOperand>
-    <MoreSpecificReturnType>
-      <code>?static</code>
-    </MoreSpecificReturnType>
     <PossiblyNullReference>
-      <code>getDepth</code>
+      <code><![CDATA[getDepth]]></code>
     </PossiblyNullReference>
   </file>
   <file src="src/Visitor/PostOrderVisitor.php">
@@ -64,7 +61,7 @@
       <code><![CDATA[$child->accept($this)]]></code>
     </MixedArgument>
     <MixedReturnTypeCoercion>
-      <code>$nodes</code>
+      <code><![CDATA[$nodes]]></code>
       <code><![CDATA[array<int, NodeInterface>]]></code>
     </MixedReturnTypeCoercion>
   </file>
@@ -73,7 +70,7 @@
       <code><![CDATA[$child->accept($this)]]></code>
     </MixedArgument>
     <MixedReturnTypeCoercion>
-      <code>$nodes</code>
+      <code><![CDATA[$nodes]]></code>
       <code><![CDATA[array<int, NodeInterface>]]></code>
     </MixedReturnTypeCoercion>
   </file>
@@ -82,7 +79,7 @@
       <code><![CDATA[$child->accept($this)]]></code>
     </MixedArgument>
     <MixedReturnTypeCoercion>
-      <code>$yield</code>
+      <code><![CDATA[$yield]]></code>
       <code><![CDATA[array<int, NodeInterface>]]></code>
     </MixedReturnTypeCoercion>
   </file>
@@ -91,18 +88,10 @@
       <code><![CDATA['Tree\Node\Node']]></code>
     </ArgumentTypeCoercion>
     <InvalidDocblock>
-      <code>array[Node]</code>
+      <code><![CDATA[array[Node]]]></code>
     </InvalidDocblock>
-    <MissingClosureReturnType>
-      <code>static function (Node $node) {</code>
-    </MissingClosureReturnType>
     <PossiblyNullReference>
-      <code>leaf</code>
+      <code><![CDATA[leaf]]></code>
     </PossiblyNullReference>
-  </file>
-  <file src="test/Unit/Node/NodeTest.php">
-    <TypeDoesNotContainType>
-      <code>assertSame</code>
-    </TypeDoesNotContainType>
   </file>
 </files>

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -11,15 +11,22 @@
 
 namespace Tree\Node;
 
+/**
+ * @template TValue
+ *
+ * @template-implements NodeInterface<TValue>
+ */
 class Node implements NodeInterface
 {
+    /** @use NodeTrait<TValue> */
     use NodeTrait;
 
     /**
+     * @param null|TValue               $value
      * @param array<int, NodeInterface> $children
      */
     public function __construct(
-        mixed $value = null,
+        $value = null,
         array $children = [],
     ) {
         $this->setValue($value);

--- a/src/Node/NodeInterface.php
+++ b/src/Node/NodeInterface.php
@@ -17,23 +17,27 @@ use Tree\Visitor\Visitor;
  * Interface for tree nodes.
  *
  * @author Nicolò Martini <nicmartnic@gmail.com>
+ *
+ * @template TValue
  */
 interface NodeInterface
 {
     /**
      * Set the value of the current node.
+     *
+     * @param TValue $value
      */
-    public function setValue(mixed $value): static;
+    public function setValue($value): static;
 
     /**
      * Get the current node value.
+     *
+     * @return TValue
      */
-    public function getValue(): mixed;
+    public function getValue();
 
     /**
      * Add a child.
-     *
-     * @return mixed
      */
     public function addChild(self $child): static;
 
@@ -58,8 +62,6 @@ interface NodeInterface
      * Replace the children set with the given one.
      *
      * @param array<int, NodeInterface> $children
-     *
-     * @return mixed
      */
     public function setChildren(array $children): static;
 
@@ -71,7 +73,7 @@ interface NodeInterface
     /**
      * Return the parent node.
      */
-    public function getParent(): ?static;
+    public function getParent(): ?self;
 
     /**
      * Retrieves all ancestors of node excluding current node.
@@ -115,7 +117,7 @@ interface NodeInterface
     /**
      * Find the root of the node.
      */
-    public function root(): static;
+    public function root(): self;
 
     /**
      * Return the distance from the current node to the root.

--- a/src/Node/NodeTrait.php
+++ b/src/Node/NodeTrait.php
@@ -13,9 +13,15 @@ namespace Tree\Node;
 
 use Tree\Visitor\Visitor;
 
+/**
+ * @template TValue
+ */
 trait NodeTrait
 {
-    private mixed $value = null;
+    /**
+     * @var null|TValue
+     */
+    private $value;
     private ?NodeInterface $parent = null;
 
     /**
@@ -23,14 +29,20 @@ trait NodeTrait
      */
     private array $children = [];
 
-    public function setValue(mixed $value): static
+    /**
+     * @param null|TValue $value
+     */
+    public function setValue($value): static
     {
         $this->value = $value;
 
         return $this;
     }
 
-    public function getValue(): mixed
+    /**
+     * @return null|TValue
+     */
+    public function getValue()
     {
         return $this->value;
     }
@@ -90,7 +102,7 @@ trait NodeTrait
         $this->parent = $parent;
     }
 
-    public function getParent(): ?static
+    public function getParent(): ?NodeInterface
     {
         return $this->parent;
     }
@@ -153,7 +165,7 @@ trait NodeTrait
         return [] === $this->children;
     }
 
-    public function root(): static
+    public function root(): NodeInterface
     {
         $node = $this;
 

--- a/src/Visitor/PostOrderVisitor.php
+++ b/src/Visitor/PostOrderVisitor.php
@@ -18,7 +18,7 @@ class PostOrderVisitor implements Visitor
     /**
      * @return array<int, NodeInterface> $node
      */
-    public function visit(NodeInterface $node): mixed
+    public function visit(NodeInterface $node): array
     {
         $nodes = [];
 

--- a/src/Visitor/YieldVisitor.php
+++ b/src/Visitor/YieldVisitor.php
@@ -18,7 +18,7 @@ class YieldVisitor implements Visitor
     /**
      * @return array<int, NodeInterface>
      */
-    public function visit(NodeInterface $node): mixed
+    public function visit(NodeInterface $node): array
     {
         if ($node->isLeaf()) {
             return [$node];

--- a/test/Unit/Node/NodeTest.php
+++ b/test/Unit/Node/NodeTest.php
@@ -69,6 +69,7 @@ final class NodeTest extends Framework\TestCase
 
     public function testSetValue(): void
     {
+        /** @var Node<\stdClass|string> $node */
         $node = new Node();
 
         $node->setValue('string value');


### PR DESCRIPTION
This pull request

- [x] Adds template/generic phpdocs for node value

Follows #.
Related to #.
Fixes #.
